### PR TITLE
Add detailed information of URI path format

### DIFF
--- a/doc_source/waf-rule-statement-fields.md
+++ b/doc_source/waf-rule-statement-fields.md
@@ -35,7 +35,8 @@ Similar to **Single query parameter**, but AWS WAF inspects the values of all pa
 Choosing this option adds 10 WCUs to the base cost\.
 
 **URI path**  
-The part of a URL that identifies a resource, for example, `/images/daily-ad.jpg`\. If you don't use a text transformation with this option, AWS WAF doesn't normalize the URI and inspects it just as it receives it from the client in the request\. 
+The part of a URL that identifies a resource, for example, `/images/daily-ad.jpg`\. This doesn't include the query string or fragment components of the URI\. For information, see [Uniform Resource Identifier \(URI\): Generic Syntax](https://tools.ietf.org/html/rfc3986#section-3.3)\.
+If you don't use a text transformation with this option, AWS WAF doesn't normalize the URI and inspects it just as it receives it from the client in the request\. 
 
 **Body**  
 The part of the request that immediately follows the request headers, evaluated as plain text\. This contains any additional data that is needed for the web request, for example, data from a form\.   


### PR DESCRIPTION
## About

### Description of changes

I found the docs of the previous version of WAF (referred to as classic or v1) has a description of the format of the URI path used as the argument of conditions (replaced with "statement" now).  Still, the current version's docs have no expression like it.  The previous one is more helpful because it refers to the reliable RFC document, and I think the current one might want to be updated to avoid ambiguity/confusion.

### Reference

- [Previous Docs](https://docs.aws.amazon.com/waf/latest/developerguide/classic-web-acl-string-conditions.html#classic-web-acl-string-conditions-values)
- [Current Docs](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-fields.html#waf-rule-statement-request-component)

## Agreement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
